### PR TITLE
trow error instead of shutting down server

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -4,9 +4,8 @@ local Timeouts, RegisteredCommands, Callbacks = {}, {}, {}
 
 AddEventHandler('onResourceStart', function(resource)
 	if GetCurrentResourceName() ~= 'msk_core' then
-        print('^1Please rename the Script to^3 msk_core^0!')
-        print('^1Server will be shutdown^0!')
-        os.exit()
+		error('^1Please rename the Script to^3 msk_core^0!')
+		return
     end
 end)
 


### PR DESCRIPTION
Why shutting down the useres server, probably not seeing the printed error message beacuse of all the prints when server is restarting?